### PR TITLE
BUGFIX: Correctly adopt nodes without fallback

### DIFF
--- a/Classes/Service/ImportService.php
+++ b/Classes/Service/ImportService.php
@@ -422,7 +422,8 @@ class ImportService
                 $propertiesToSet[$key] = $value;
             }
         }
-        if ($propertiesToSet === []) {
+        // don't adopt node if no properties have changed and there is a fallback in place
+        if ($propertiesToSet === [] && count($targetContentContext->getDimensions()[$this->languageDimension]) > 1) {
             return;
         }
 


### PR DESCRIPTION
Nodes without any changes to properties will now be adopted if they have no active fallback.