### PR TITLE
TASK: Make DimensionPresetSource discovery more consistent during import

### DIFF
--- a/Classes/Service/ImportService.php
+++ b/Classes/Service/ImportService.php
@@ -162,7 +162,11 @@ class ImportService
                 throw new \RuntimeException('No target language given (neither in XML nor as argument)', 1475578770);
             }
 
-            $this->languageDimensionPreset = $this->contentDimensionPresetSource->findPresetByUriSegment($this->languageDimension, $this->targetLanguage);
+            $this->languageDimensionPreset = $this->contentDimensionPresetSource->findPresetByDimensionValues($this->languageDimension, [$this->targetLanguage]);
+
+            if ($this->languageDimensionPreset === null) {
+                throw new \RuntimeException(sprintf('No language dimension preset found for language "%s".', $this->targetLanguage), 1571230670);
+            }
 
             $sitePackageKey = $xmlReader->getAttribute('sitePackageKey');
             if (!$this->packageManager->isPackageAvailable($sitePackageKey)) {


### PR DESCRIPTION
Hi there!

This PR introduces the following changes:

* Use `findPresetByDimensionValues` instead of `findPresetByUriSegment`,
since every other part of the service logic ist based on dimension
values and not the URI path segment.
* Throw an exception, if no DimensionPresetSource could be found

This solves a problem that you'll get, when `dimensionValue` and `uriPathSegment` of your language dimension diverge.

This is potentially breaking, but could also be fine, since instances in which both values are the same are still going to work, while any other setup would currently render the Import command unusable without this change.

