### PR TITLE
FEATURE: add option to exclude child document nodes 

### DIFF
--- a/Classes/Command/TradosCommandController.php
+++ b/Classes/Command/TradosCommandController.php
@@ -47,16 +47,17 @@ class TradosCommandController extends CommandController
      * @param string|null $filename Path and filename to the XML file to create.
      * @param string|null $modifiedAfter
      * @param boolean $ignoreHidden
+     * @param boolean $excludeChildDocuments
      * @return void
      * @throws \Exception
      */
-    public function exportCommand(string $startingPoint, string $sourceLanguage, string $targetLanguage = null, string $filename = null, string $modifiedAfter = null, bool $ignoreHidden = true)
+    public function exportCommand(string $startingPoint, string $sourceLanguage, string $targetLanguage = null, string $filename = null, string $modifiedAfter = null, bool $ignoreHidden = true, bool $excludeChildDocuments = false)
     {
         if ($modifiedAfter !== null) {
             $modifiedAfter = new \DateTime($modifiedAfter);
         }
 
-        $this->exportService->initialize($startingPoint, $sourceLanguage, $targetLanguage, $modifiedAfter, $ignoreHidden);
+        $this->exportService->initialize($startingPoint, $sourceLanguage, $targetLanguage, $modifiedAfter, $ignoreHidden, $excludeChildDocuments);
 
         try {
             if ($filename === null) {

--- a/README.md
+++ b/README.md
@@ -26,14 +26,15 @@ The export command:
       ./flow trados:export [<options>] <starting point> <source language>
     
     ARGUMENTS:
-      --starting-point     The node with which to start the export, relative to the
-                           site node. Optional.
-      --source-language    The language to use as base for the export.
+      --starting-point              The node with which to start the export, relative to the
+                                    site node. Optional.
+      --source-language             The language to use as base for the export.
     
     OPTIONS:
-      --target-language    The target language for the translation, optional.
-      --filename           Path and filename to the XML file to create.
+      --target-language             The target language for the translation, optional.
+      --filename                    Path and filename to the XML file to create.
       --modified-after
+      --exclude-child-documents     If child documents should not be included in the export.
 
 The import command:
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "description": "XML import/export for Neos, suited for Trados translations",
     "require": {
-        "neos/neos": "^4.3 || ^5.0 || ^7.0",
+        "neos/neos": "^4.3 || ^5.0 || ^7.0 || ^8.0",
         "php": "^7.4 || ^8.0",
         "ext-xmlwriter": "*",
         "ext-xmlreader": "*"


### PR DESCRIPTION
We had a use case in a project where we needed to export only a specific page itself without any child pages. That's why we added the option to do exactly this (`--exclude-child-documents`).
On the way, some deprecated classes were replaced and the project was declared compatible with the current flow version.