### PR TITLE
BUGFIX: Ensure compatibility with Neos 5

### DIFF
--- a/Classes/Service/ExportService.php
+++ b/Classes/Service/ExportService.php
@@ -14,7 +14,6 @@ namespace Flownative\Neos\Trados\Service;
 use Neos\ContentRepository\Domain\Model\NodeData;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
-use Neos\ContentRepository\Domain\Utility\NodePaths;
 use Neos\Flow\Annotations as Flow;
 use Neos\Neos\Domain\Model\Site;
 use Neos\Neos\Domain\Service\ContentContext;
@@ -49,15 +48,6 @@ class ExportService
      * @var ContextFactoryInterface
      */
     protected $contextFactory;
-
-    /**
-     * Doctrine's Entity Manager. Note that "ObjectManager" is the name of the related
-     * interface ...
-     *
-     * @Flow\Inject
-     * @var \Doctrine\Common\Persistence\ObjectManager
-     */
-    protected $entityManager;
 
     /**
      * @Flow\Inject

--- a/Classes/Service/ImportService.php
+++ b/Classes/Service/ImportService.php
@@ -37,7 +37,7 @@ class ImportService
 
     /**
      * @Flow\Inject
-     * @var \Neos\Flow\Package\PackageManagerInterface
+     * @var \Neos\Flow\Package\PackageManager
      */
     protected $packageManager;
 


### PR DESCRIPTION
* PackageManagerInterface does no longer exist, but the PackageManager is available in all Flow Versions so far
* The Doctrine ObjectManager FQCN changed in recent Doctrine Versions. Since the property is unused we can simply remove it