### PR TITLE
BUGFIX: Enable --modifiedAfter feature

### DIFF
--- a/Classes/Service/ExportService.php
+++ b/Classes/Service/ExportService.php
@@ -254,6 +254,15 @@ class ExportService extends AbstractService
                         $parent = $parentNode->getNodeData();
                     }
                 }
+
+                if (!is_null($this->modifiedAfter)) {
+                    // filter out node if last modification date is _before_ modifiedAfter option
+                    $lastModified = $nodeData->getLastModificationDateTime();
+
+                    if ($lastModified < $this->modifiedAfter) {
+                        return false;
+                    }
+                }
             }
 
             return true;


### PR DESCRIPTION
I'm not sure if this was ever used, but currently the `--modifiedAfter` option has no effect on the export, despite adding an attribute for it in the resulting xml file.

I added a basic implementation and it seems to work.