### PR TITLE
TASK: Prevent null exception in Export->writeProperty()

### DIFF
--- a/Classes/Service/ExportService.php
+++ b/Classes/Service/ExportService.php
@@ -360,7 +360,7 @@ class ExportService extends AbstractService
         $this->xmlWriter->endElement();
     }
 
-    protected function writeProperty(string $propertyName, string $propertyValue): void
+    protected function writeProperty(string $propertyName, ?string $propertyValue = ''): void
     {
         $this->xmlWriter->startElement($propertyName);
         $this->xmlWriter->writeAttribute('type', 'string');


### PR DESCRIPTION
Prevent null exception in Export->writeProperty() when property value is null.

## Why
We had null exceptions when the export encountered properties with null values.

## Fix
`ExportService->writeProperty` can now take `null` als `$propertyValue` and falls back to empty string (`''`), which to me leads to a correct result in the export (empty property).
